### PR TITLE
Close request body after request (to resolve open file leak)

### DIFF
--- a/clients/highwater/highwater.go
+++ b/clients/highwater/highwater.go
@@ -139,8 +139,12 @@ func (client *HighwaterClient) PostServer(eventName, token string, params map[st
 	req, _ := http.NewRequest("GET", host.String(), bytes.NewBuffer(client.adjustEventParams(params)))
 	req.Header.Add("x-tidepool-session-token", token)
 
-	if _, err := client.httpClient.Do(req); err != nil {
+	res, err := client.httpClient.Do(req)
+	if err != nil {
 		log.Printf("Error PostServer: [%s]  err[%v] ", req.URL, err)
+	}
+	if res != nil && res.Body != nil {
+		defer res.Body.Close()
 	}
 
 	return
@@ -158,8 +162,12 @@ func (client *HighwaterClient) PostThisUser(eventName, token string, params map[
 	req, _ := http.NewRequest("GET", host.String(), bytes.NewBuffer(client.adjustEventParams(params)))
 	req.Header.Add("x-tidepool-session-token", token)
 
-	if _, err := client.httpClient.Do(req); err != nil {
+	res, err := client.httpClient.Do(req)
+	if err != nil {
 		log.Printf("Error PostThisUser: [%s]  err[%v] ", req.URL, err)
+	}
+	if res != nil && res.Body != nil {
+		defer res.Body.Close()
 	}
 
 	return


### PR DESCRIPTION
@jh-bate Only `hydrophone` uses this functionality in go-common, but it does allow an open file leak in `hydrophone`.