### PR TITLE
Added feature flag.

### DIFF
--- a/clients/hakken/hakken.go
+++ b/clients/hakken/hakken.go
@@ -22,6 +22,7 @@ type HakkenClientConfig struct {
 	HeartbeatInterval jepson.Duration `json:"heartbeatInterval"` // Time elapsed between heartbeats and watch polls
 	PollInterval      jepson.Duration `json:"pollInterval"`      // Time elapsed between coordinator gossip polls
 	ResyncInterval    jepson.Duration `json:"resyncInterval"`    // Time elapsed between checks for new coordinators at Host
+	SkipHakken        bool            `json:"skipHakken"`        // True is Hakken service is not used
 }
 
 type HakkenClientBuilder struct {


### PR DESCRIPTION
This adds a boolean to the configuration parameters.  Default is false.  So, if not present, value is false and there will be no change to the current behavior (of contacting the hakken service).

However, when true, the intent is that Tidepool backend services do not attempt to contact the hakken service.  

@pazaan Please review this and the corresponding change in shoreline (which currently exits if it cannot contact hakken).