### PR TITLE
Construct Mongo connection string from Config

### DIFF
--- a/clients/mongo/mongo.go
+++ b/clients/mongo/mongo.go
@@ -2,35 +2,78 @@ package mongo
 
 import (
 	"crypto/tls"
-	"fmt"
 	"log"
 	"net"
-	"net/url"
-	"strconv"
-	"strings"
 	"time"
 
+	"github.com/globalsign/mgo"
 	"github.com/tidepool-org/go-common/errors"
 	"github.com/tidepool-org/go-common/jepson"
-	"github.com/globalsign/mgo"
 )
 
 type Config struct {
 	ConnectionString string           `json:"connectionString"`
 	Timeout          *jepson.Duration `json:"timeout"`
+	User             string           `json:"user"`
+	Password         string           `json:"password"`
+	Database         string           `json:"database"`
+	Ssl              bool             `json:"ssl"`
+	Hosts            string           `json:"hosts"`
+	OptParams        string           `json:"optParams"`
+}
+
+func (config *Config) ToConnectionString() (string, error) {
+	if config.ConnectionString != "" {
+		return config.ConnectionString, nil
+	}
+	if config.Database == "" {
+		return "", errors.New("Must specify a database in Mongo config")
+	}
+	cs := "mongodb://"
+	if config.User != "" {
+		cs += config.User
+		if config.Password != "" {
+			cs += ":"
+			cs += config.Password
+		}
+		cs += "@"
+	}
+
+	if config.Hosts != "" {
+		cs += config.Hosts
+		cs += "/"
+	} else {
+		cs += "localhost/"
+	}
+
+	if config.Database != "" {
+		cs += config.Database
+	}
+
+	if config.Ssl {
+		cs += "?ssl=true"
+	} else {
+		cs += "?ssl=false"
+	}
+
+	if config.OptParams != "" {
+		cs += "&"
+		cs += config.OptParams
+	}
+	return cs, nil
 }
 
 func Connect(config *Config) (*mgo.Session, error) {
-	if config.ConnectionString == "" {
-		return nil, errors.New("Must specify a ConnectionString on mongo config")
+	connectionString, err := config.ToConnectionString()
+	if err != nil {
+		return nil, err
 	}
-
 	dur := 20 * time.Second
 	if config.Timeout != nil {
 		dur = time.Duration(*config.Timeout)
 	}
 
-	dialInfo, err := mgo.ParseURL(config.ConnectionString) 
+	dialInfo, err := mgo.ParseURL(connectionString)
 	if err != nil {
 		return nil, err
 	}
@@ -42,150 +85,7 @@ func Connect(config *Config) (*mgo.Session, error) {
 			return tls.Dial("tcp", addr.String(), &tls.Config{InsecureSkipVerify: true})
 		}
 	}
-	
 	log.Printf("Initializing with config[%+v], dur[%v]", config, dur)
 	return mgo.DialWithInfo(dialInfo)
 }
 
-
-/*
- All following code originally C&Pd from mgo.  It has been adjusted to allow
- for automatic handling of ssl connections based on a connection string parameter
-*/
-
-// mgo - MongoDB driver for Go
-//
-// Copyright (c) 2010-2012 - Gustavo Niemeyer <gustavo@niemeyer.net>
-//
-// All rights reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions are met:
-//
-// 1. Redistributions of source code must retain the above copyright notice, this
-//    list of conditions and the following disclaimer.
-// 2. Redistributions in binary form must reproduce the above copyright notice,
-//    this list of conditions and the following disclaimer in the documentation
-//    and/or other materials provided with the distribution.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-// DialWithTimeout works like Dial, but uses timeout as the amount of time to
-// wait for a server to respond when first connecting and also on follow up
-// operations in the session. If timeout is zero, the call may block
-// forever waiting for a connection to be made.
-//
-// See SetSyncTimeout for customizing the timeout for the session.
-func DialWithTimeout(url string, timeout time.Duration) (*mgo.Session, error) {
-	uinfo, err := parseURL(url)
-	if err != nil {
-		return nil, err
-	}
-	direct := false
-	mechanism := ""
-	service := ""
-	source := ""
-	var dialServer func(*mgo.ServerAddr) (net.Conn, error)
-	for k, v := range uinfo.options {
-		switch k {
-		case "authSource":
-			source = v
-		case "authMechanism":
-			mechanism = v
-		case "gssapiServiceName":
-			service = v
-		case "ssl":
-			if ssl, sslErr := strconv.ParseBool(v); sslErr == nil && ssl {
-				dialServer = func(addr *mgo.ServerAddr) (net.Conn, error) {
-					return tls.Dial("tcp", addr.String(), &tls.Config{InsecureSkipVerify: true})
-				}
-			}
-		case "connect":
-			if v == "direct" {
-				direct = true
-				break
-			}
-			if v == "replicaSet" {
-				break
-			}
-			fallthrough
-		default:
-			return nil, errors.New("unsupported connection URL option: " + k + "=" + v)
-		}
-	}
-	info := mgo.DialInfo{
-		Addrs:      uinfo.addrs,
-		Direct:     direct,
-		Timeout:    timeout,
-		Database:   uinfo.db,
-		Username:   uinfo.user,
-		Password:   uinfo.pass,
-		Mechanism:  mechanism,
-		Service:    service,
-		Source:     source,
-		DialServer: dialServer,
-	}
-	return mgo.DialWithInfo(&info)
-}
-
-func isOptSep(c rune) bool {
-	return c == ';' || c == '&'
-}
-
-type urlInfo struct {
-	addrs   []string
-	user    string
-	pass    string
-	db      string
-	options map[string]string
-}
-
-func parseURL(s string) (*urlInfo, error) {
-	if strings.HasPrefix(s, "mongodb://") {
-		s = s[10:]
-	}
-	info := &urlInfo{options: make(map[string]string)}
-	if c := strings.Index(s, "?"); c != -1 {
-		for _, pair := range strings.FieldsFunc(s[c+1:], isOptSep) {
-			l := strings.SplitN(pair, "=", 2)
-			if len(l) != 2 || l[0] == "" || l[1] == "" {
-				return nil, errors.New("connection option must be key=value: " + pair)
-			}
-			info.options[l[0]] = l[1]
-		}
-		s = s[:c]
-	}
-	if c := strings.Index(s, "@"); c != -1 {
-		pair := strings.SplitN(s[:c], ":", 2)
-		if len(pair) > 2 || pair[0] == "" {
-			return nil, errors.New("credentials must be provided as user:pass@host")
-		}
-		var err error
-		info.user, err = url.QueryUnescape(pair[0])
-		if err != nil {
-			return nil, fmt.Errorf("cannot unescape username in URL: %q", pair[0])
-		}
-		if len(pair) > 1 {
-			info.pass, err = url.QueryUnescape(pair[1])
-			if err != nil {
-				return nil, fmt.Errorf("cannot unescape password in URL")
-			}
-		}
-		s = s[c+1:]
-	}
-	if c := strings.Index(s, "/"); c != -1 {
-		info.db = s[c+1:]
-		s = s[:c]
-	}
-	info.addrs = strings.Split(s, ",")
-	return info, nil
-}

--- a/clients/mongo/mongo_test.go
+++ b/clients/mongo/mongo_test.go
@@ -1,0 +1,86 @@
+package mongo
+import (
+	"testing"
+)
+
+func TestNoDatabase(t *testing.T) {
+	x := Config{}
+	_, err := x.ToConnectionString()
+
+	if err == nil {
+	  t.Error("database is required")
+        }
+}
+
+
+func TestDatabase(t *testing.T) {
+	x := Config{ Database: "admin"}
+	s, err := x.ToConnectionString()
+
+	if err != nil {
+	  t.Error("should not error")
+        }
+	if s != "mongodb://localhost/admin?ssl=false" {
+	  t.Errorf("found %v", s)
+        }
+}
+
+func TestUser(t *testing.T) {
+	x := Config{ Database: "admin", User: "derrick"}
+	s, err := x.ToConnectionString()
+
+	if err != nil {
+	  t.Error("should not error")
+        }
+	if s != "mongodb://derrick@localhost/admin?ssl=false" {
+	  t.Errorf("found %v", s)
+        }
+}
+
+func TestPassword(t *testing.T) {
+	x := Config{ Database: "admin", User: "derrick", Password: "password"}
+	s, err := x.ToConnectionString()
+
+	if err != nil {
+	  t.Error("should not error")
+        }
+	if s != "mongodb://derrick:password@localhost/admin?ssl=false" {
+	  t.Errorf("found %v", s)
+        }
+}
+
+func TestSsl(t *testing.T) {
+	x := Config{ Database: "admin", User: "derrick", Password: "password", Ssl: true}
+	s, err := x.ToConnectionString()
+
+	if err != nil {
+	  t.Error("should not error")
+        }
+	if s != "mongodb://derrick:password@localhost/admin?ssl=true" {
+	  t.Errorf("found %v", s)
+        }
+}
+
+func TestHosts(t *testing.T) {
+	x := Config{ Database: "admin", User: "derrick", Password: "password", Ssl: true, Hosts: "mongodb1,mongodb2"}
+	s, err := x.ToConnectionString()
+
+	if err != nil {
+	  t.Error("should not error")
+        }
+	if s != "mongodb://derrick:password@mongodb1,mongodb2/admin?ssl=true" {
+	  t.Errorf("found %v", s)
+        }
+}
+
+func TestOptParams(t *testing.T) {
+	x := Config{ Database: "admin", User: "derrick", Password: "password", Ssl: true, Hosts: "mongodb1,mongodb2", OptParams: "x=y"}
+	s, err := x.ToConnectionString()
+
+	if err != nil {
+	  t.Error("should not error")
+        }
+	if s != "mongodb://derrick:password@mongodb1,mongodb2/admin?ssl=true&x=y" {
+	  t.Errorf("found %v", s)
+        }
+}


### PR DESCRIPTION
This PR enables one to pass Mongo configuration as individual components instead of a single connection string. 

We also delete dead code.