### PR TITLE
[BACK-1937] Add ability to create custodial accounts owned by clinics

### DIFF
--- a/clients/mocks.go
+++ b/clients/mocks.go
@@ -50,3 +50,7 @@ func (mock *SeagullMock) GetCollection(userID, collectionName, token string, v i
 	json.Unmarshal([]byte(`{"Something":"anit no thing", "patient": {"birthday": "2016-01-01"}}`), &v)
 	return nil
 }
+
+func (mock *SeagullMock) UpdateCollection(userID, collectionName, token string, v interface{}) error {
+	return nil
+}

--- a/clients/seagull.go
+++ b/clients/seagull.go
@@ -1,6 +1,7 @@
 package clients
 
 import (
+	"bytes"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -26,6 +27,13 @@ type (
 		// token -- a server token or the user token
 		// v - the interface to return the value in
 		GetCollection(userID, collectionName, token string, v interface{}) error
+		// Updates arbitrary collection information
+		//
+		// userID -- the Tidepool-assigned userId
+		// collectionName -- the collection being retrieved
+		// token -- a server token or the user token
+		// v - the interface to return the value in
+		UpdateCollection(userID, collectionName, token string, v interface{}) error
 	}
 
 	SeagullClient struct {
@@ -125,6 +133,40 @@ func (client *SeagullClient) GetCollection(userID, collectionName, token string,
 			log.Println("Error parsing JSON results", err)
 			return err
 		}
+		return nil
+	case http.StatusNotFound:
+		log.Printf("No [%s] collection found for [%s]", collectionName, userID)
+		return nil
+	default:
+		return &status.StatusError{status.NewStatusf(res.StatusCode, "Unknown response code from service[%s]", req.URL)}
+	}
+
+}
+
+func (client *SeagullClient) UpdateCollection(userID, collectionName, token string, v interface{}) error {
+	host := client.getHost()
+	if host == nil {
+		return nil
+	}
+	host.Path = path.Join(host.Path, userID, collectionName)
+
+	body, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	req, _ := http.NewRequest("POST", host.String(), bytes.NewBuffer(body))
+	req.Header.Add("x-tidepool-session-token", token)
+
+	res, err := client.httpClient.Do(req)
+	if err != nil {
+		log.Printf("Problem when looking up collection for userID[%s]. %s", userID, err)
+		return err
+	}
+	defer res.Body.Close()
+
+	switch res.StatusCode {
+	case http.StatusOK:
 		return nil
 	case http.StatusNotFound:
 		log.Printf("No [%s] collection found for [%s]", collectionName, userID)

--- a/clients/seagull.go
+++ b/clients/seagull.go
@@ -156,6 +156,7 @@ func (client *SeagullClient) UpdateCollection(userID, collectionName, token stri
 	}
 
 	req, _ := http.NewRequest("POST", host.String(), bytes.NewBuffer(body))
+	req.Header.Add("content-type", "application/json")
 	req.Header.Add("x-tidepool-session-token", token)
 
 	res, err := client.httpClient.Do(req)

--- a/clients/shoreline/shoreline.go
+++ b/clients/shoreline/shoreline.go
@@ -20,6 +20,10 @@ import (
 	"github.com/tidepool-org/go-common/jepson"
 )
 
+var (
+	ErrDuplicateUser = errors.New("user already exists")
+)
+
 // Client interface that we will implement and mock
 type Client interface {
 	Start() error
@@ -472,6 +476,8 @@ func (client *ShorelineClient) CreateCustodialUserForClinic(clinicId string, use
 				return nil, err
 			}
 			return ud, nil
+		case http.StatusConflict:
+			return nil, ErrDuplicateUser
 		default:
 			return nil, fmt.Errorf("unexpected status code from service: %v", res.StatusCode)
 		}

--- a/clients/shoreline/shoreline.go
+++ b/clients/shoreline/shoreline.go
@@ -444,7 +444,7 @@ func (client *ShorelineClient) CreateCustodialUserForClinic(clinicId string, use
 
 	type request struct {
 		Username *string  `json:"username,omitempty"`
-		Emails   []string `json:"username,omitempty"`
+		Emails   []string `json:"emails,omitempty"`
 	}
 
 	payload := request{}

--- a/clients/shoreline/shorelineMock.go
+++ b/clients/shoreline/shorelineMock.go
@@ -50,3 +50,7 @@ func (client *ShorelineMockClient) GetUser(userID, token string) (*UserData, err
 func (client *ShorelineMockClient) UpdateUser(userID string, userUpdate UserUpdate, token string) error {
 	return nil
 }
+
+func (client *ShorelineMockClient) CreateCustodialUserForClinic(clinicId string, userData CustodialUserData, token string) (*UserData, error) {
+	return nil, nil
+}

--- a/events/config.go
+++ b/events/config.go
@@ -9,7 +9,7 @@ import (
 const DeadLetterSuffix = "-dead-letters"
 
 type CloudEventsConfig struct {
-	EventSource           string   `envconfig:"CLOUD_EVENTS_SOURCE" required:"true"`
+	EventSource           string   `envconfig:"CLOUD_EVENTS_SOURCE" required:"false"`
 	KafkaBrokers          []string `envconfig:"KAFKA_BROKERS" required:"true"`
 	KafkaConsumerGroup    string   `envconfig:"KAFKA_CONSUMER_GROUP" required:"false"`
 	KafkaTopic            string   `envconfig:"KAFKA_TOPIC" default:"events"`

--- a/events/consumer.go
+++ b/events/consumer.go
@@ -2,78 +2,59 @@ package events
 
 import (
 	"context"
-	"fmt"
 	"github.com/Shopify/sarama"
 	"github.com/cloudevents/sdk-go/protocol/kafka_sarama/v2"
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 	"github.com/cloudevents/sdk-go/v2/binding"
-	"github.com/tidepool-org/go-common/errors"
 	"log"
-	"sync"
 )
 
-var ErrConsumerStopped = errors.New("consumer has been stopped")
-
 type EventConsumer interface {
-	RegisterHandler(handler EventHandler)
 	Start() error
 	Stop() error
 }
 
-type SaramaConsumer struct {
-	config             *CloudEventsConfig
-	consumerGroup      sarama.ConsumerGroup
-	ready              chan bool
-	stop               chan struct{}
-	stopOnce           *sync.Once
-	topic              string
-	wg                 *sync.WaitGroup
+type ConsumerFactory func() (MessageConsumer, error)
+
+type MessageConsumer interface {
+	Initialize(config *CloudEventsConfig) error
+	HandleKafkaMessage(cm *sarama.ConsumerMessage) error
+}
+
+type CloudEventsMessageConsumer struct {
 	handlers           []EventHandler
 	deadLetterProducer *KafkaCloudEventsProducer
 }
 
-func NewSaramaCloudEventsConsumer(config *CloudEventsConfig) (EventConsumer, error) {
-	if err := validateConsumerConfig(config); err != nil {
-		return nil, err
-	}
-
-	return &SaramaConsumer{
-		config:   config,
-		topic:    config.GetPrefixedTopic(),
-		wg:       &sync.WaitGroup{},
-		ready:    make(chan bool, 1),
-		stop:     make(chan struct{}),
-		stopOnce: &sync.Once{},
-		handlers: make([]EventHandler, 0),
+func NewCloudEventsMessageHandler(handlers []EventHandler) (*CloudEventsMessageConsumer, error) {
+	return &CloudEventsMessageConsumer{
+		handlers: handlers,
 	}, nil
 }
 
-func (s *SaramaConsumer) Setup(session sarama.ConsumerGroupSession) error {
-	// Mark the consumer as ready
-	close(s.ready)
-	return nil
-}
-
-func (s *SaramaConsumer) Cleanup(session sarama.ConsumerGroupSession) error {
-	return nil
-}
-
-func (s *SaramaConsumer) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
-	for message := range claim.Messages() {
-		m := kafka_sarama.NewMessageFromConsumerMessage(message)
-		// just ignore non-cloud event messages
-		if rs, rserr := binding.ToEvent(context.Background(), m); rserr == nil {
-			s.handleCloudEvent(*rs)
+func (c *CloudEventsMessageConsumer) Initialize(config *CloudEventsConfig) error {
+	if config.IsDeadLettersEnabled() {
+		producer, err := NewKafkaCloudEventsProducerForDeadLetters(config)
+		if err != nil {
+			return err
 		}
-		session.MarkMessage(message, "")
+		c.deadLetterProducer = producer
 	}
 
 	return nil
 }
 
-func (s *SaramaConsumer) handleCloudEvent(ce cloudevents.Event) {
+func (c *CloudEventsMessageConsumer) HandleKafkaMessage(cm *sarama.ConsumerMessage) error {
+	message := kafka_sarama.NewMessageFromConsumerMessage(cm)
+	if rs, rserr := binding.ToEvent(context.Background(), message); rserr == nil {
+		c.handleCloudEvent(*rs)
+	}
+	return nil
+}
+
+func (c *CloudEventsMessageConsumer) handleCloudEvent(ce cloudevents.Event) {
 	var errors []error
-	for _, handler := range s.handlers {
+	for _, handler := range c.handlers {
 		if handler.CanHandle(ce) {
 			if err := handler.Handle(ce); err != nil {
 				errors = append(errors, err)
@@ -81,106 +62,13 @@ func (s *SaramaConsumer) handleCloudEvent(ce cloudevents.Event) {
 		}
 	}
 	if len(errors) != 0 {
-		log.Printf("Sending event %v to dead-letter topic due to handler error(s): %v", ce.ID(), errors)
-		s.sendToDeadLetterTopic(ce)
+		log.Printf("Sending event %v to dead-letter topic due to handler error(c): %v", ce.ID(), errors)
+		c.sendToDeadLetterTopic(ce)
 	}
 }
 
-func (s *SaramaConsumer) sendToDeadLetterTopic(ce cloudevents.Event) {
-	if err := s.deadLetterProducer.SendCloudEvent(context.Background(), ce); err != nil {
+func (c *CloudEventsMessageConsumer) sendToDeadLetterTopic(ce cloudevents.Event) {
+	if err := c.deadLetterProducer.SendCloudEvent(context.Background(), ce); err != nil {
 		log.Printf("Failed to send event %v to dead-letter topic: %v", ce, err)
 	}
-}
-
-func (s *SaramaConsumer) RegisterHandler(handler EventHandler) {
-	s.handlers = append(s.handlers, handler)
-}
-
-func (s *SaramaConsumer) Start() error {
-	if err := s.initialize(); err != nil {
-		return err
-	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		<-s.stop
-		cancel()
-	}()
-
-	errChan := make(chan error)
-	s.wg.Add(1)
-	go func() {
-		defer s.wg.Done()
-		for {
-			// `Consume` should be called inside an infinite loop, when a
-			// server-side rebalance happens, the consumer session will need to be
-			// recreated to get the new claims
-			if err := s.consumerGroup.Consume(ctx, []string{s.topic}, s); err != nil {
-				log.Printf("Error from consumer: %v", err)
-				// It's not clear whether this condition can be true
-				if err == context.Canceled {
-					err = ErrConsumerStopped
-				}
-				errChan <- err
-				return
-			}
-			// check if context was cancelled, signaling that the consumer should stop
-			if ctx.Err() != nil {
-				errChan <- ErrConsumerStopped
-				return
-			}
-			s.ready = make(chan bool)
-		}
-	}()
-
-	err := <-errChan
-	if err == ErrConsumerStopped {
-		return err
-	}
-
-	// The consumer group was terminated with an unexpected error.
-	// We need to call stop, so we cancel the context and stop the
-	// go routine so it doesn't leak on restart.
-	if e := s.Stop(); e != nil {
-		err = fmt.Errorf("%w: %s", err, e.Error())
-	}
-
-	return err
-}
-
-func (s *SaramaConsumer) Stop() error {
-	// Initialization failed
-	if s.consumerGroup == nil {
-		return nil
-	}
-
-	// Signal that the consumer group should be terminated
-	s.stopOnce.Do(func() {
-		s.stop <- struct{}{}
-	})
-
-	// Wait for the consumer group to exit
-	s.wg.Wait()
-	return s.consumerGroup.Close()
-}
-
-func (s *SaramaConsumer) initialize() error {
-	cg, err := sarama.NewConsumerGroup(
-		s.config.KafkaBrokers,
-		s.config.KafkaConsumerGroup,
-		s.config.SaramaConfig,
-	)
-	if err != nil {
-		return err
-	}
-
-	if s.config.IsDeadLettersEnabled() {
-		s.deadLetterProducer, err = NewKafkaCloudEventsProducerForDeadLetters(s.config)
-		if err != nil {
-			return err
-		}
-	}
-
-	s.consumerGroup = cg
-	return nil
 }

--- a/events/consumer_group.go
+++ b/events/consumer_group.go
@@ -1,0 +1,147 @@
+package events
+
+import (
+	"context"
+	"fmt"
+	"github.com/Shopify/sarama"
+	"github.com/tidepool-org/go-common/errors"
+	"log"
+	"sync"
+)
+
+var ErrConsumerStopped = errors.New("consumer has been stopped")
+
+type SaramaConsumerGroup struct {
+	config        *CloudEventsConfig
+	consumerGroup sarama.ConsumerGroup
+	consumer      MessageConsumer
+	ready         chan bool
+	stop          chan struct{}
+	stopOnce      *sync.Once
+	topic         string
+	wg            *sync.WaitGroup
+}
+
+func NewSaramaConsumerGroup(config *CloudEventsConfig, consumer MessageConsumer) (EventConsumer, error) {
+	if err := validateConsumerConfig(config); err != nil {
+		return nil, err
+	}
+
+	return &SaramaConsumerGroup{
+		config:   config,
+		consumer: consumer,
+		topic:    config.GetPrefixedTopic(),
+		wg:       &sync.WaitGroup{},
+		ready:    make(chan bool, 1),
+		stop:     make(chan struct{}),
+		stopOnce: &sync.Once{},
+	}, nil
+}
+
+func (s *SaramaConsumerGroup) Setup(session sarama.ConsumerGroupSession) error {
+	// Mark the consumer as ready
+	close(s.ready)
+	return nil
+}
+
+func (s *SaramaConsumerGroup) Cleanup(session sarama.ConsumerGroupSession) error {
+	return nil
+}
+
+func (s *SaramaConsumerGroup) ConsumeClaim(session sarama.ConsumerGroupSession, claim sarama.ConsumerGroupClaim) error {
+	for message := range claim.Messages() {
+		if err := s.consumer.HandleKafkaMessage(message); err != nil {
+			log.Printf("failed to process kafka message: %v", err)
+			return err
+		}
+		session.MarkMessage(message, "")
+	}
+
+	return nil
+}
+
+func (s *SaramaConsumerGroup) Start() error {
+	if err := s.initialize(); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-s.stop
+		cancel()
+	}()
+
+	errChan := make(chan error)
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		for {
+			// `Consume` should be called inside an infinite loop, when a
+			// server-side rebalance happens, the consumer session will need to be
+			// recreated to get the new claims
+			if err := s.consumerGroup.Consume(ctx, []string{s.topic}, s); err != nil {
+				log.Printf("Error from consumer: %v", err)
+				// It's not clear whether this condition can be true
+				if err == context.Canceled {
+					err = ErrConsumerStopped
+				}
+				errChan <- err
+				return
+			}
+			// check if context was cancelled, signaling that the consumer should stop
+			if ctx.Err() != nil {
+				errChan <- ErrConsumerStopped
+				return
+			}
+			s.ready = make(chan bool)
+		}
+	}()
+
+	err := <-errChan
+	if err == ErrConsumerStopped {
+		return err
+	}
+
+	// The consumer group was terminated with an unexpected error.
+	// We need to call stop, so we cancel the context and stop the
+	// go routine so it doesn't leak on restart.
+	if e := s.Stop(); e != nil {
+		err = fmt.Errorf("%w: %s", err, e.Error())
+	}
+
+	return err
+}
+
+func (s *SaramaConsumerGroup) Stop() error {
+	// Initialization failed
+	if s.consumerGroup == nil {
+		return nil
+	}
+
+	// Signal that the consumer group should be terminated
+	s.stopOnce.Do(func() {
+		s.stop <- struct{}{}
+	})
+
+	// Wait for the consumer group to exit
+	s.wg.Wait()
+	return s.consumerGroup.Close()
+}
+
+func (s *SaramaConsumerGroup) initialize() error {
+	cg, err := sarama.NewConsumerGroup(
+		s.config.KafkaBrokers,
+		s.config.KafkaConsumerGroup,
+		s.config.SaramaConfig,
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := s.consumer.Initialize(s.config); err != nil {
+		return err
+	}
+
+	s.consumerGroup = cg
+	return nil
+}


### PR DESCRIPTION
This PR adds the newly created endpoint for creating custodial accounts for clinics to the shoreline client