### PR TITLE
[BACK-2290] Dexcom patient connection

### DIFF
--- a/clients/auth.go
+++ b/clients/auth.go
@@ -2,6 +2,7 @@ package clients
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"net/http"
 	"net/url"
@@ -87,7 +88,7 @@ func (b *authClientBuilder) Build() *AuthClient {
 func (client *AuthClient) CreateRestrictedToken(userID string, expirationTime time.Time, paths []string, token string) (*RestrictedToken, error) {
 	host := client.getHost()
 	if host == nil {
-		return nil, errors.New("No known user-api hosts.")
+		return nil, errors.New("No known auth hosts")
 	}
 
 	host.Path = path.Join(host.Path, "v1", "users", userID, "restricted_tokens")
@@ -101,6 +102,9 @@ func (client *AuthClient) CreateRestrictedToken(userID string, expirationTime ti
 	}
 	defer res.Body.Close()
 
+	s, _ := json.MarshalIndent(res, "", "\t")
+	fmt.Println("res", string(s))
+
 	switch res.StatusCode {
 	case http.StatusCreated:
 		var td RestrictedToken
@@ -111,7 +115,7 @@ func (client *AuthClient) CreateRestrictedToken(userID string, expirationTime ti
 		return &td, nil
 	default:
 		return nil, &status.StatusError{
-			Status: status.NewStatusf(res.StatusCode, "Unknown response code from service[%s]", req.URL),
+			Status: status.NewStatusf(res.StatusCode, "Unexpected response code from service[%s]", req.URL),
 		}
 	}
 }

--- a/clients/auth.go
+++ b/clients/auth.go
@@ -166,8 +166,7 @@ func (client *AuthClient) CreateRestrictedToken(userID string, expirationTime ti
 		case http.StatusCreated:
 			var td RestrictedToken
 			if err = json.NewDecoder(res.Body).Decode(&td); err != nil {
-				log.Println("Error parsing JSON results", err)
-				return nil, nil
+				return nil, errors.Wrap(err, "Error parsing JSON results")
 			}
 			return &td, nil
 		default:
@@ -207,8 +206,7 @@ func (client *AuthClient) UpdateRestrictedToken(tokenID string, expirationTime t
 		case http.StatusOK:
 			var td RestrictedToken
 			if err = json.NewDecoder(res.Body).Decode(&td); err != nil {
-				log.Println("Error parsing JSON results", err)
-				return nil, nil
+				return nil, errors.Wrap(err, "Error parsing JSON results")
 			}
 			return &td, nil
 		default:

--- a/clients/auth.go
+++ b/clients/auth.go
@@ -21,7 +21,7 @@ type (
 		//userID  -- the Tidepool-assigned userID
 		//
 		// returns the Auth Sources for the user
-		ListUserRestrictedTokens(userID string, filter *RestrictedTokenFilter, pagination *Pagination, token string) (RestrictedTokens, error)
+		ListUserRestrictedTokens(userID string, token string) (RestrictedTokens, error)
 		CreateRestrictedToken(userID string, expirationTime time.Time, paths []string, token string) (*RestrictedToken, error)
 		UpdateRestrictedToken(tokenId string, expirationTime time.Time, paths []string, token string) (*RestrictedToken, error)
 		DeleteRestrictedToken(tokenId string, token string) error
@@ -64,11 +64,6 @@ type RestrictedTokenUpdate struct {
 
 type RestrictedTokenFilter struct{}
 
-type Pagination struct {
-	Page int `json:"page,omitempty"`
-	Size int `json:"size,omitempty"`
-}
-
 func NewAuthClientBuilder() *authClientBuilder {
 	return &authClientBuilder{}
 }
@@ -104,6 +99,41 @@ func (b *authClientBuilder) Build() *AuthClient {
 		httpClient:    b.httpClient,
 		hostGetter:    b.hostGetter,
 		tokenProvider: b.tokenProvider,
+	}
+}
+
+// ListUserRestrictedTokens listsrestricted tokens for a given user
+func (client *AuthClient) ListUserRestrictedTokens(userID string, token string) (RestrictedTokens, error) {
+	host := client.getHost()
+	if host == nil {
+		return nil, errors.New("No known auth hosts")
+	}
+	host.Path = path.Join(host.Path, "v1", "users", userID, "restricted_tokens")
+
+	req, _ := http.NewRequest("GET", host.String(), nil)
+	req.Header.Add("x-tidepool-session-token", token)
+
+	res, err := client.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == 200 {
+		retVal := RestrictedTokens{}
+		if err := json.NewDecoder(res.Body).Decode(&retVal); err != nil {
+			log.Println(err)
+			return nil, &status.StatusError{
+				Status: status.NewStatusf(res.StatusCode, "ListUserRestrictedTokens Unable to parse response[%s]", req.URL),
+			}
+		}
+		return retVal, nil
+	} else if res.StatusCode == 404 {
+		return nil, nil
+	} else {
+		return nil, &status.StatusError{
+			Status: status.NewStatusf(res.StatusCode, "Unexpected response code from service[%s]", req.URL),
+		}
 	}
 }
 
@@ -212,41 +242,6 @@ func (client *AuthClient) DeleteRestrictedToken(tokenID string, token string) er
 	default:
 		return &status.StatusError{
 			Status: status.NewStatusf(res.StatusCode, "Unknown response code from service[%s]", req.URL),
-		}
-	}
-}
-
-// ListUserRestrictedTokens listsrestricted tokens for a given user
-func (client *AuthClient) ListUserRestrictedTokens(userID string, filter *RestrictedTokenFilter, pagination *Pagination, token string) (RestrictedTokens, error) {
-	host := client.getHost()
-	if host == nil {
-		return nil, errors.New("No known auth hosts")
-	}
-	host.Path = path.Join(host.Path, "v1", "users", userID, "restricted_tokens")
-
-	req, _ := http.NewRequest("GET", host.String(), nil)
-	req.Header.Add("x-tidepool-session-token", token)
-
-	res, err := client.httpClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode == 200 {
-		retVal := RestrictedTokens{}
-		if err := json.NewDecoder(res.Body).Decode(&retVal); err != nil {
-			log.Println(err)
-			return nil, &status.StatusError{
-				Status: status.NewStatusf(res.StatusCode, "ListUserRestrictedTokens Unable to parse response[%s]", req.URL),
-			}
-		}
-		return retVal, nil
-	} else if res.StatusCode == 404 {
-		return nil, nil
-	} else {
-		return nil, &status.StatusError{
-			Status: status.NewStatusf(res.StatusCode, "Unexpected response code from service[%s]", req.URL),
 		}
 	}
 }

--- a/clients/auth.go
+++ b/clients/auth.go
@@ -1,0 +1,127 @@
+package clients
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+
+	"github.com/tidepool-org/go-common/clients/disc"
+	"github.com/tidepool-org/go-common/clients/status"
+	"github.com/tidepool-org/go-common/errors"
+)
+
+type (
+	//Interface so that we can mock authClient for tests
+	Auth interface {
+		//userID  -- the Tidepool-assigned userID
+		//
+		// returns the Auth Sources for the user
+		CreateRestrictedToken(userID string, expirationTime time.Time, paths []string, token string) (*RestrictedToken, error)
+	}
+
+	AuthClient struct {
+		httpClient    *http.Client    // store a reference to the http client so we can reuse it
+		hostGetter    disc.HostGetter // The getter that provides the host to talk to for the client
+		tokenProvider TokenProvider   // An object that provides tokens for communicating with data
+	}
+
+	authClientBuilder struct {
+		httpClient    *http.Client    // store a reference to the http client so we can reuse it
+		hostGetter    disc.HostGetter // The getter that provides the host to talk to for the client
+		tokenProvider TokenProvider   // An object that provides tokens for communicating with data
+	}
+)
+
+// RestrictedToken is the data structure returned from a successful create restricted token query.
+type RestrictedToken struct {
+	ID             string     `json:"id" bson:"id"`
+	UserID         string     `json:"userId" bson:"userId"`
+	Paths          *[]string  `json:"paths,omitempty" bson:"paths,omitempty"`
+	ExpirationTime time.Time  `json:"expirationTime" bson:"expirationTime"`
+	CreatedTime    time.Time  `json:"createdTime" bson:"createdTime"`
+	ModifiedTime   *time.Time `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
+}
+
+func NewAuthClientBuilder() *authClientBuilder {
+	return &authClientBuilder{}
+}
+
+func (b *authClientBuilder) WithHttpClient(httpClient *http.Client) *authClientBuilder {
+	b.httpClient = httpClient
+	return b
+}
+
+func (b *authClientBuilder) WithHostGetter(hostGetter disc.HostGetter) *authClientBuilder {
+	b.hostGetter = hostGetter
+	return b
+}
+
+func (b *authClientBuilder) WithTokenProvider(tokenProvider TokenProvider) *authClientBuilder {
+	b.tokenProvider = tokenProvider
+	return b
+}
+
+func (b *authClientBuilder) Build() *AuthClient {
+	if b.hostGetter == nil {
+		panic("authClient requires a hostGetter to be set")
+	}
+	if b.tokenProvider == nil {
+		panic("authClient requires a tokenProvider to be set")
+	}
+
+	if b.httpClient == nil {
+		b.httpClient = http.DefaultClient
+	}
+
+	return &AuthClient{
+		httpClient:    b.httpClient,
+		hostGetter:    b.hostGetter,
+		tokenProvider: b.tokenProvider,
+	}
+}
+
+// CreateRestrictedToken creates a restricted token for a given user
+func (client *AuthClient) CreateRestrictedToken(userID string, expirationTime time.Time, paths []string, token string) (*RestrictedToken, error) {
+	host := client.getHost()
+	if host == nil {
+		return nil, errors.New("No known user-api hosts.")
+	}
+
+	host.Path = path.Join(host.Path, "v1", "users", userID, "restricted_tokens")
+
+	req, _ := http.NewRequest("POST", host.String(), nil)
+	req.Header.Add("x-tidepool-session-token", token)
+
+	res, err := client.httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "couldn't create restricted token")
+	}
+	defer res.Body.Close()
+
+	switch res.StatusCode {
+	case http.StatusCreated:
+		var td RestrictedToken
+		if err = json.NewDecoder(res.Body).Decode(&td); err != nil {
+			log.Println("Error parsing JSON results", err)
+			return nil, nil
+		}
+		return &td, nil
+	default:
+		return nil, &status.StatusError{
+			Status: status.NewStatusf(res.StatusCode, "Unknown response code from service[%s]", req.URL),
+		}
+	}
+}
+
+func (client *AuthClient) getHost() *url.URL {
+	if hostArr := client.hostGetter.HostGet(); len(hostArr) > 0 {
+		cpy := new(url.URL)
+		*cpy = hostArr[0]
+		return cpy
+	} else {
+		return nil
+	}
+}

--- a/clients/auth.go
+++ b/clients/auth.go
@@ -204,7 +204,7 @@ func (client *AuthClient) UpdateRestrictedToken(tokenID string, expirationTime t
 		defer res.Body.Close()
 
 		switch res.StatusCode {
-		case http.StatusCreated:
+		case http.StatusOK:
 			var td RestrictedToken
 			if err = json.NewDecoder(res.Body).Decode(&td); err != nil {
 				log.Println("Error parsing JSON results", err)

--- a/clients/data.go
+++ b/clients/data.go
@@ -96,7 +96,7 @@ func (client *DataClient) ListSources(userID string) (DataSourceArray, error) {
 	if host == nil {
 		return nil, errors.New("No known data hosts")
 	}
-	host.Path = path.Join(host.Path, "/v1/users/", userID, "/data_sources")
+	host.Path = path.Join(host.Path, "v1", "users", userID, "data_sources")
 
 	req, _ := http.NewRequest("GET", host.String(), nil)
 	req.Header.Add("x-tidepool-session-token", client.tokenProvider.TokenProvide())

--- a/clients/data.go
+++ b/clients/data.go
@@ -37,20 +37,20 @@ type (
 )
 
 type DataSource struct {
-	ID                *string              `json:"id,omitempty" bson:"id,omitempty"`
-	UserID            *string              `json:"userId,omitempty" bson:"userId,omitempty"`
-	ProviderType      *string              `json:"providerType,omitempty" bson:"providerType,omitempty"`
-	ProviderName      *string              `json:"providerName,omitempty" bson:"providerName,omitempty"`
-	ProviderSessionID *string              `json:"providerSessionId,omitempty" bson:"providerSessionId,omitempty"`
-	State             *string              `json:"state,omitempty" bson:"state,omitempty"`
-	Error             *errors.Serializable `json:"error,omitempty" bson:"error,omitempty"`
-	DataSetIDs        *[]string            `json:"dataSetIds,omitempty" bson:"dataSetIds,omitempty"`
-	EarliestDataTime  *time.Time           `json:"earliestDataTime,omitempty" bson:"earliestDataTime,omitempty"`
-	LatestDataTime    *time.Time           `json:"latestDataTime,omitempty" bson:"latestDataTime,omitempty"`
-	LastImportTime    *time.Time           `json:"lastImportTime,omitempty" bson:"lastImportTime,omitempty"`
-	CreatedTime       *time.Time           `json:"createdTime,omitempty" bson:"createdTime,omitempty"`
-	ModifiedTime      *time.Time           `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
-	Revision          *int                 `json:"revision,omitempty" bson:"revision,omitempty"`
+	ID                *string              `json:"id,omitempty"`
+	UserID            *string              `json:"userId,omitempty"`
+	ProviderType      *string              `json:"providerType,omitempty"`
+	ProviderName      *string              `json:"providerName,omitempty"`
+	ProviderSessionID *string              `json:"providerSessionId,omitempty"`
+	State             *string              `json:"state,omitempty"`
+	Error             *errors.Serializable `json:"error,omitempty"`
+	DataSetIDs        *[]string            `json:"dataSetIds,omitempty"`
+	EarliestDataTime  *time.Time           `json:"earliestDataTime,omitempty"`
+	LatestDataTime    *time.Time           `json:"latestDataTime,omitempty"`
+	LastImportTime    *time.Time           `json:"lastImportTime,omitempty"`
+	CreatedTime       *time.Time           `json:"createdTime,omitempty"`
+	ModifiedTime      *time.Time           `json:"modifiedTime,omitempty"`
+	Revision          *int                 `json:"revision,omitempty"`
 }
 
 func NewDataClientBuilder() *dataClientBuilder {

--- a/clients/data.go
+++ b/clients/data.go
@@ -37,6 +37,7 @@ type (
 )
 
 type DataSource struct {
+	ObjectID          *string              `json:"_id,omitempty"`
 	ID                *string              `json:"id,omitempty"`
 	UserID            *string              `json:"userId,omitempty"`
 	ProviderType      *string              `json:"providerType,omitempty"`

--- a/clients/data.go
+++ b/clients/data.go
@@ -37,7 +37,6 @@ type (
 )
 
 type DataSource struct {
-	ObjectID          *string              `json:"_id,omitempty"`
 	ID                *string              `json:"id,omitempty"`
 	UserID            *string              `json:"userId,omitempty"`
 	ProviderType      *string              `json:"providerType,omitempty"`

--- a/clients/data.go
+++ b/clients/data.go
@@ -14,13 +14,13 @@ import (
 )
 
 type (
-	SourceArray []*Source
+	DataSourceArray []*DataSource
 	//Inteface so that we can mock dataClient for tests
 	Data interface {
 		//userID  -- the Tidepool-assigned userID
 		//
 		// returns the Data Sources for the user
-		ListSources(userID string) (SourceArray, error)
+		ListSources(userID string) (DataSourceArray, error)
 	}
 
 	DataClient struct {
@@ -36,7 +36,7 @@ type (
 	}
 )
 
-type Source struct {
+type DataSource struct {
 	ID                *string              `json:"id,omitempty" bson:"id,omitempty"`
 	UserID            *string              `json:"userId,omitempty" bson:"userId,omitempty"`
 	ProviderType      *string              `json:"providerType,omitempty" bson:"providerType,omitempty"`
@@ -91,7 +91,7 @@ func (b *dataClientBuilder) Build() *DataClient {
 	}
 }
 
-func (client *DataClient) ListSources(userID string) (SourceArray, error) {
+func (client *DataClient) ListSources(userID string) (DataSourceArray, error) {
 	host := client.getHost()
 	if host == nil {
 		return nil, errors.New("No known data hosts")
@@ -108,7 +108,7 @@ func (client *DataClient) ListSources(userID string) (SourceArray, error) {
 	defer res.Body.Close()
 
 	if res.StatusCode == 200 {
-		retVal := SourceArray{}
+		retVal := DataSourceArray{}
 		if err := json.NewDecoder(res.Body).Decode(&retVal); err != nil {
 			log.Println(err)
 			return nil, &status.StatusError{status.NewStatus(500, "ListSources Unable to parse response.")}

--- a/clients/data.go
+++ b/clients/data.go
@@ -1,0 +1,132 @@
+package clients
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"net/url"
+	"path"
+	"time"
+
+	"github.com/tidepool-org/go-common/clients/disc"
+	"github.com/tidepool-org/go-common/clients/status"
+	"github.com/tidepool-org/go-common/errors"
+)
+
+type (
+	SourceArray []*Source
+	//Inteface so that we can mock dataClient for tests
+	Data interface {
+		//userID  -- the Tidepool-assigned userID
+		//
+		// returns the Data Sources for the user
+		ListSources(userID string) (SourceArray, error)
+	}
+
+	DataClient struct {
+		httpClient    *http.Client    // store a reference to the http client so we can reuse it
+		hostGetter    disc.HostGetter // The getter that provides the host to talk to for the client
+		tokenProvider TokenProvider   // An object that provides tokens for communicating with data
+	}
+
+	dataClientBuilder struct {
+		httpClient    *http.Client    // store a reference to the http client so we can reuse it
+		hostGetter    disc.HostGetter // The getter that provides the host to talk to for the client
+		tokenProvider TokenProvider   // An object that provides tokens for communicating with data
+	}
+)
+
+type Source struct {
+	ID                *string              `json:"id,omitempty" bson:"id,omitempty"`
+	UserID            *string              `json:"userId,omitempty" bson:"userId,omitempty"`
+	ProviderType      *string              `json:"providerType,omitempty" bson:"providerType,omitempty"`
+	ProviderName      *string              `json:"providerName,omitempty" bson:"providerName,omitempty"`
+	ProviderSessionID *string              `json:"providerSessionId,omitempty" bson:"providerSessionId,omitempty"`
+	State             *string              `json:"state,omitempty" bson:"state,omitempty"`
+	Error             *errors.Serializable `json:"error,omitempty" bson:"error,omitempty"`
+	DataSetIDs        *[]string            `json:"dataSetIds,omitempty" bson:"dataSetIds,omitempty"`
+	EarliestDataTime  *time.Time           `json:"earliestDataTime,omitempty" bson:"earliestDataTime,omitempty"`
+	LatestDataTime    *time.Time           `json:"latestDataTime,omitempty" bson:"latestDataTime,omitempty"`
+	LastImportTime    *time.Time           `json:"lastImportTime,omitempty" bson:"lastImportTime,omitempty"`
+	CreatedTime       *time.Time           `json:"createdTime,omitempty" bson:"createdTime,omitempty"`
+	ModifiedTime      *time.Time           `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
+	Revision          *int                 `json:"revision,omitempty" bson:"revision,omitempty"`
+}
+
+func NewDataClientBuilder() *dataClientBuilder {
+	return &dataClientBuilder{}
+}
+
+func (b *dataClientBuilder) WithHttpClient(httpClient *http.Client) *dataClientBuilder {
+	b.httpClient = httpClient
+	return b
+}
+
+func (b *dataClientBuilder) WithHostGetter(hostGetter disc.HostGetter) *dataClientBuilder {
+	b.hostGetter = hostGetter
+	return b
+}
+
+func (b *dataClientBuilder) WithTokenProvider(tokenProvider TokenProvider) *dataClientBuilder {
+	b.tokenProvider = tokenProvider
+	return b
+}
+
+func (b *dataClientBuilder) Build() *DataClient {
+	if b.hostGetter == nil {
+		panic("dataClient requires a hostGetter to be set")
+	}
+	if b.tokenProvider == nil {
+		panic("dataClient requires a tokenProvider to be set")
+	}
+
+	if b.httpClient == nil {
+		b.httpClient = http.DefaultClient
+	}
+
+	return &DataClient{
+		httpClient:    b.httpClient,
+		hostGetter:    b.hostGetter,
+		tokenProvider: b.tokenProvider,
+	}
+}
+
+func (client *DataClient) ListSources(userID string) (SourceArray, error) {
+	host := client.getHost()
+	if host == nil {
+		return nil, errors.New("No known data hosts")
+	}
+	host.Path = path.Join(host.Path, "/v1/users/", userID, "/data_sources")
+
+	req, _ := http.NewRequest("GET", host.String(), nil)
+	req.Header.Add("x-tidepool-session-token", client.tokenProvider.TokenProvide())
+
+	res, err := client.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode == 200 {
+		retVal := SourceArray{}
+		if err := json.NewDecoder(res.Body).Decode(&retVal); err != nil {
+			log.Println(err)
+			return nil, &status.StatusError{status.NewStatus(500, "ListSources Unable to parse response.")}
+		}
+		return retVal, nil
+	} else if res.StatusCode == 404 {
+		return nil, nil
+	} else {
+		return nil, &status.StatusError{status.NewStatusf(res.StatusCode, "Unknown response code from service[%s]", req.URL)}
+	}
+}
+
+func (client *DataClient) getHost() *url.URL {
+	if hostArr := client.hostGetter.HostGet(); len(hostArr) > 0 {
+		cpy := new(url.URL)
+		*cpy = hostArr[0]
+		return cpy
+	} else {
+		return nil
+	}
+}

--- a/clients/data.go
+++ b/clients/data.go
@@ -15,7 +15,7 @@ import (
 
 type (
 	DataSourceArray []*DataSource
-	//Inteface so that we can mock dataClient for tests
+	//Interface so that we can mock dataClient for tests
 	Data interface {
 		//userID  -- the Tidepool-assigned userID
 		//

--- a/clients/shoreline/shoreline.go
+++ b/clients/shoreline/shoreline.go
@@ -36,6 +36,7 @@ type Client interface {
 	UpdateUser(userID string, userUpdate UserUpdate, token string) error
 	CreateCustodialUserForClinic(clinicId string, userData CustodialUserData, token string) (*UserData, error)
 	DeleteUserSessions(userID, token string) error
+	CreateRestrictedToken(userID, expirationTime string, paths []string, token string) (*RestrictedToken, error)
 }
 
 // ShorelineClient manages the local data for a client. A client is intended to be shared among multiple
@@ -85,6 +86,16 @@ type CustodialUserData struct {
 type TokenData struct {
 	UserID   string // the UserID stored in the token
 	IsServer bool   // true or false depending on whether the token was a servertoken
+}
+
+// TokenData is the data structure returned from a successful CheckToken query.
+type RestrictedToken struct {
+	ID             string     `json:"id" bson:"id"`
+	UserID         string     `json:"userId" bson:"userId"`
+	Paths          *[]string  `json:"paths,omitempty" bson:"paths,omitempty"`
+	ExpirationTime time.Time  `json:"expirationTime" bson:"expirationTime"`
+	CreatedTime    time.Time  `json:"createdTime" bson:"createdTime"`
+	ModifiedTime   *time.Time `json:"modifiedTime,omitempty" bson:"modifiedTime,omitempty"`
 }
 
 type ShorelineClientBuilder struct {
@@ -514,10 +525,10 @@ func (client *ShorelineClient) DeleteUserSessions(userID, token string) error {
 }
 
 // DeleteUserSession deletes all active sessions for a given user
-func (client *ShorelineClient) CreateRestrictedToken(userID, expirationTime string, paths []string, token string) error {
+func (client *ShorelineClient) CreateRestrictedToken(userID, expirationTime string, paths []string, token string) (*RestrictedToken, error) {
 	host := client.getHost()
 	if host == nil {
-		return errors.New("No known user-api hosts.")
+		return nil, errors.New("No known user-api hosts.")
 	}
 
 	host.Path = path.Join(host.Path, "v1", "users", userID, "restricted_tokens")
@@ -527,15 +538,20 @@ func (client *ShorelineClient) CreateRestrictedToken(userID, expirationTime stri
 
 	res, err := client.httpClient.Do(req)
 	if err != nil {
-		return errors.Wrap(err, "couldn't create restricted token")
+		return nil, errors.Wrap(err, "couldn't create restricted token")
 	}
 	defer res.Body.Close()
 
 	switch res.StatusCode {
-	case http.StatusNoContent:
-		return nil
+	case http.StatusCreated:
+		var td RestrictedToken
+		if err = json.NewDecoder(res.Body).Decode(&td); err != nil {
+			log.Println("Error parsing JSON results", err)
+			return nil, nil
+		}
+		return &td, nil
 	default:
-		return &status.StatusError{
+		return nil, &status.StatusError{
 			Status: status.NewStatusf(res.StatusCode, "Unknown response code from service[%s]", req.URL),
 		}
 	}

--- a/clients/shoreline/shoreline.go
+++ b/clients/shoreline/shoreline.go
@@ -36,7 +36,7 @@ type Client interface {
 	UpdateUser(userID string, userUpdate UserUpdate, token string) error
 	CreateCustodialUserForClinic(clinicId string, userData CustodialUserData, token string) (*UserData, error)
 	DeleteUserSessions(userID, token string) error
-	CreateRestrictedToken(userID, expirationTime string, paths []string, token string) (*RestrictedToken, error)
+	CreateRestrictedToken(userID, expirationTime time.Time, paths []string, token string) (*RestrictedToken, error)
 }
 
 // ShorelineClient manages the local data for a client. A client is intended to be shared among multiple
@@ -525,7 +525,7 @@ func (client *ShorelineClient) DeleteUserSessions(userID, token string) error {
 }
 
 // DeleteUserSession deletes all active sessions for a given user
-func (client *ShorelineClient) CreateRestrictedToken(userID, expirationTime string, paths []string, token string) (*RestrictedToken, error) {
+func (client *ShorelineClient) CreateRestrictedToken(userID string, expirationTime time.Time, paths []string, token string) (*RestrictedToken, error) {
 	host := client.getHost()
 	if host == nil {
 		return nil, errors.New("No known user-api hosts.")

--- a/clients/shoreline/shoreline.go
+++ b/clients/shoreline/shoreline.go
@@ -36,7 +36,7 @@ type Client interface {
 	UpdateUser(userID string, userUpdate UserUpdate, token string) error
 	CreateCustodialUserForClinic(clinicId string, userData CustodialUserData, token string) (*UserData, error)
 	DeleteUserSessions(userID, token string) error
-	CreateRestrictedToken(userID, expirationTime time.Time, paths []string, token string) (*RestrictedToken, error)
+	CreateRestrictedToken(userID string, expirationTime time.Time, paths []string, token string) (*RestrictedToken, error)
 }
 
 // ShorelineClient manages the local data for a client. A client is intended to be shared among multiple

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -10,6 +10,10 @@ type WrappedError struct {
 	m string
 }
 
+type Serializable struct {
+	Error error
+}
+
 func (err *WrappedError) Error() string {
 	return err.m + ": " + err.error.Error()
 }

--- a/events/mailer.go
+++ b/events/mailer.go
@@ -1,9 +1,6 @@
 package events
 
 import (
-	"encoding/json"
-	"fmt"
-
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 )
 
@@ -44,12 +41,6 @@ func (d DelegatingEmailEventHandler) CanHandle(ce cloudevents.Event) bool {
 }
 
 func (d DelegatingEmailEventHandler) Handle(ce cloudevents.Event) error {
-	s, _ := json.MarshalIndent(ce.Type(), "", "\t")
-	fmt.Println("ce.Type", string(s))
-
-	s, _ = json.MarshalIndent(ce, "", "\t")
-	fmt.Println("ce", string(s))
-
 	if ce.Type() != SendEmailTemplateEventType {
 		// ignore invalid events
 		return nil

--- a/events/mailer.go
+++ b/events/mailer.go
@@ -1,6 +1,11 @@
 package events
 
-import cloudevents "github.com/cloudevents/sdk-go/v2"
+import (
+	"encoding/json"
+	"fmt"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
 
 const (
 	SendEmailTemplateEventType = "email_template:send"
@@ -39,6 +44,12 @@ func (d DelegatingEmailEventHandler) CanHandle(ce cloudevents.Event) bool {
 }
 
 func (d DelegatingEmailEventHandler) Handle(ce cloudevents.Event) error {
+	s, _ := json.MarshalIndent(ce.Type(), "", "\t")
+	fmt.Println("ce.Type", string(s))
+
+	s, _ = json.MarshalIndent(ce, "", "\t")
+	fmt.Println("ce", string(s))
+
 	if ce.Type() != SendEmailTemplateEventType {
 		// ignore invalid events
 		return nil


### PR DESCRIPTION
[BACK-2290]

As discussed over Slack, I ended up feeling that adding the `auth` and `data` clients to go-common, while less desireable than using the `oapi-codegen`, was much quicker for the moment, and when we have some free cycles, we can structure all of the platform service clients in a better way. 

[BACK-2290]: https://tidepool.atlassian.net/browse/BACK-2290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ