### PR TITLE
remove platform specific bits from Todd's cascading import

### DIFF
--- a/asyncevents/sarama_test.go
+++ b/asyncevents/sarama_test.go
@@ -21,7 +21,7 @@ func TestSaramaAsyncEventsConsumerLifecycle(s *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 		handler := &nullSaramaConsumerGroupHandler{}
-		eventsConsumer := NewSaramaEventsConsumer(consumerGroup, handler, topics...)
+		eventsConsumer := NewSaramaConsumerGroupManager(consumerGroup, handler, topics...)
 		err := launchStart(ctx, t, eventsConsumer)
 		if !errors.Is(err, nil) {
 			t.Errorf("expected nil error, got %v", err)
@@ -31,7 +31,7 @@ func TestSaramaAsyncEventsConsumerLifecycle(s *testing.T) {
 	s.Run("reports errors (that aren't context.Canceled)", func(t *testing.T) {
 		consumerGroup := &erroringSaramaConsumerGroup{err: errTest}
 		handler := &nullSaramaConsumerGroupHandler{}
-		eventsConsumer := NewSaramaEventsConsumer(consumerGroup, handler, topics...)
+		eventsConsumer := NewSaramaConsumerGroupManager(consumerGroup, handler, topics...)
 		err := launchStart(context.Background(), t, eventsConsumer)
 		if !errors.Is(err, errTest) {
 			t.Errorf("expected %s, got %v", errTest, err)
@@ -197,7 +197,7 @@ func ExampleFib() {
 // It uses a channel to know that the goroutine has seen some amount of CPU
 // time, which isn't guaranteed to alleviate the race of calling Start, but in
 // practice seems to be sufficient. Running with -count 10000 had 0 failures.
-func launchStart(ctx context.Context, t testing.TB, ec *SaramaEventsConsumer) (err error) {
+func launchStart(ctx context.Context, t testing.TB, ec *SaramaConsumerGroupManager) (err error) {
 	t.Helper()
 	runReturned := make(chan error)
 	go func() {

--- a/asyncevents/startstopadapter.go
+++ b/asyncevents/startstopadapter.go
@@ -1,0 +1,124 @@
+package asyncevents
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Runner abstracts [SaramaConsumerGroupManager], which is intended to be extended with
+// additional capabilities and behaviors.
+type Runner interface {
+	Run(context.Context) error
+}
+
+// BlockingStartStopAdapter for [SaramaConsumerGroupManager] to use Start and Stop methods.
+//
+// This adapter provides a base for more specific adaptation to adjust behavior to their
+// needs. For example [NonBlockingStartStopAdapter] fits well with Uber's fx.Lifecycle,
+// while this adapter is more adaptable to platform's event.Runner interface.
+type BlockingStartStopAdapter struct {
+	Runner Runner
+
+	cancelMu   sync.Mutex
+	cancelFunc context.CancelFunc
+}
+
+func NewBlockingStartStopAdapter(runner Runner) *BlockingStartStopAdapter {
+	return &BlockingStartStopAdapter{
+		Runner: runner,
+	}
+}
+
+func (a *BlockingStartStopAdapter) Start(ctx context.Context) error {
+	cancelCtx, err := a.init(ctx)
+	if err != nil {
+		return err
+	}
+	return a.Runner.Run(cancelCtx)
+}
+
+func (a *BlockingStartStopAdapter) init(ctx context.Context) (context.Context, error) {
+	a.cancelMu.Lock()
+	defer a.cancelMu.Unlock()
+
+	if a.cancelFunc != nil {
+		return nil, fmt.Errorf("can't start consumer, it's already running")
+	}
+	cancelCtx, cancelFunc := context.WithCancel(ctx)
+	a.cancelFunc = cancelFunc
+	return cancelCtx, nil
+}
+
+func (a *BlockingStartStopAdapter) Stop(_ context.Context) error {
+	a.cancelMu.Lock()
+	defer a.cancelMu.Unlock()
+
+	if a.cancelFunc == nil {
+		return fmt.Errorf("can't stop consumer, it's not running")
+	}
+
+	a.cancelFunc()
+	a.cancelFunc = nil
+
+	return nil
+}
+
+// NonBlockingStartStopAdapter for [SaramaConsumerGroupManager] for non-blocking Start and
+// Stop methods.
+//
+// To facilitate error reporting during non-blocking operation, a callback can be provided,
+// which if defined, will be called with errors that cause a [SaramaConsumerGroupManager]'s
+// Run method to return. In addition, when the callback is defined, panics from within Run
+// are recovered, converted to errors, and passed to the callback before being discarded.
+type NonBlockingStartStopAdapter struct {
+	*BlockingStartStopAdapter
+
+	onError func(error)
+}
+
+func NewNonBlockingStartStopAdapter(consumer Runner, onError func(error)) *NonBlockingStartStopAdapter {
+	blocking := NewBlockingStartStopAdapter(consumer)
+	return &NonBlockingStartStopAdapter{
+		BlockingStartStopAdapter: blocking,
+		onError:                  onError,
+	}
+}
+
+func (a *NonBlockingStartStopAdapter) Start(ctx context.Context) error {
+	go a.start(ctx)
+	return nil
+}
+
+func (a *NonBlockingStartStopAdapter) start(ctx context.Context) {
+	defer a.maybeRecover()
+
+	if err := a.BlockingStartStopAdapter.Start(ctx); err != nil {
+		if a.onError != nil {
+			a.onError(err)
+		}
+	}
+}
+
+// maybeRecover uses a callback, if defined, to process recovered panics.
+//
+// If the callback isn't defined, the panic will be re-raised.
+func (a *NonBlockingStartStopAdapter) maybeRecover() {
+	if r := recover(); r != nil {
+		if a.onError != nil {
+			a.onError(a.wrapPanic(r))
+		} else {
+			panic(r)
+		}
+	}
+}
+
+// wrapPanic converts a non-error value to an error for passing to an on-error callback.
+//
+// Existing error values are wrapped, to allow later unwrapping.
+func (a *NonBlockingStartStopAdapter) wrapPanic(r any) error {
+	if err, ok := r.(error); ok {
+		return fmt.Errorf("consumer panicked: %w", err)
+	}
+	return fmt.Errorf("consumer panicked: %s", r)
+}

--- a/asyncevents/startstopadapter_test.go
+++ b/asyncevents/startstopadapter_test.go
@@ -1,0 +1,291 @@
+package asyncevents
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestBlockingStartStopAdapter_StartWhenAlreadyStarted(t *testing.T) {
+	ctx := context.Background()
+	a := NewBlockingStartStopAdapter(newTestConsumer(t, nil))
+	if err := a.Start(ctx); err != nil {
+		t.Fatalf("expected nil error, got %s", err)
+	}
+
+	got := a.Start(ctx)
+	if got == nil {
+		t.Errorf("expected error, got nil")
+	} else if !strings.Contains(got.Error(), "it's already running") {
+		t.Errorf("expected error to contain \"it's already running\", got %s", got)
+	}
+}
+
+func TestBlockingStartStopAdapter_StopWhenNotStarted(t *testing.T) {
+	ctx := context.Background()
+	a := NewBlockingStartStopAdapter(newTestConsumer(t, nil))
+
+	got := a.Stop(ctx)
+	if got == nil {
+		t.Errorf("expected error, got nil")
+	} else if !strings.Contains(got.Error(), "it's not running") {
+		t.Errorf("expected error to contain \"it's not running\", got %s", got)
+	}
+}
+
+func TestBlockingStartStopAdapter_StopsWhenCanceled(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	t.Cleanup(cancel)
+	run, started := runUntilCanceled(t)
+	a := NewBlockingStartStopAdapter(newTestConsumer(t, run))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		if err := a.Start(ctx); err != nil {
+			t.Errorf("expected nil error from Start, got %s", err)
+		}
+	}()
+	<-started
+
+	got := a.Stop(ctx)
+	if got != nil {
+		t.Errorf("expected nil error from Stop, got %s", got)
+	}
+	wg.Wait()
+}
+
+func TestBlockingStartStopAdapter_ReturnsErrorWhenDeadlineExceeded(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Millisecond)
+	t.Cleanup(cancel)
+	run, started := runUntilCanceled(t)
+	a := NewBlockingStartStopAdapter(newTestConsumer(t, run))
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := a.Start(ctx)
+		if err == nil || !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("expected deadline exceeded error, got %v", err)
+		}
+	}()
+	<-started
+	wg.Wait()
+}
+
+func TestNonBlockingStartStopAdapter_StartDoesntBlock(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	t.Cleanup(cancel)
+	run, _ := runUntilCanceled(t)
+	a := NewNonBlockingStartStopAdapter(newTestConsumer(t, run), nil)
+
+	start := time.Now()
+	if err := a.Start(ctx); err != nil {
+		t.Errorf("expected nil error, got %s", err)
+	}
+	if time.Since(start) > 10*time.Millisecond {
+		t.Errorf("expected start to return immediately, but it took longer than expected")
+	}
+}
+
+func TestNonBlockingStartStopAdapter_StopsWhenCalled(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	t.Cleanup(cancel)
+	run, started := runUntilCanceled(t)
+	a := NewNonBlockingStartStopAdapter(newTestConsumer(t, run), nil)
+
+	if err := a.Start(ctx); err != nil {
+		t.Errorf("expected nil error, got %s", err)
+	}
+	<-started
+
+	if err := a.Stop(ctx); err != nil {
+		t.Errorf("expected nil error, got %s", err)
+	}
+}
+
+func TestNonBlockingStartStopAdapter_UsesCallback(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	t.Cleanup(cancel)
+	run, done := runReturningErrorAfter(t, time.Millisecond)
+	cbErrs := []error{}
+	cb := func(err error) {
+		cbErrs = append(cbErrs, err)
+	}
+	a := NewNonBlockingStartStopAdapter(newTestConsumer(t, run), cb)
+
+	if err := a.Start(ctx); err != nil {
+		t.Errorf("expected nil error, got %s", err)
+	}
+	<-done
+	if len(cbErrs) < 1 {
+		t.Errorf("expected the callback to be called, but it wasn't")
+		err := cbErrs[0]
+		if !strings.Contains(err.Error(), "blowing up") {
+			t.Errorf("expected callback error to contain \"blowing up\", got: %s", err)
+		}
+	}
+}
+
+func TestNonBlockingStartStopAdapter_RecoversPanicsWithCallback(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	t.Cleanup(cancel)
+	run, done := runPanickingAfter(t, time.Millisecond)
+	cbErrs := []error{}
+	cb := func(err error) {
+		cbErrs = append(cbErrs, err)
+	}
+	a := NewNonBlockingStartStopAdapter(newTestConsumer(t, run), cb)
+
+	if err := a.Start(ctx); err != nil {
+		t.Errorf("expected nil error, got %s", err)
+	}
+	<-done
+	// It can take a little while for the panic to propagate even after done is closed.
+	startedWaiting := time.Now()
+	for len(cbErrs) == 0 && time.Since(startedWaiting) < time.Second {
+		time.Sleep(time.Microsecond)
+	}
+	if len(cbErrs) < 1 {
+		t.Errorf("expected the callback to be called, but it wasn't")
+		err := cbErrs[0]
+		if !strings.Contains(err.Error(), "panic in the disco") {
+			t.Errorf("expected callback error to contain \"panic in the disco\", got: %s", err)
+		}
+	}
+}
+
+func TestNonBlockingStartStopAdapter_RecoversPanicsWithCallbackIncludingError(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
+	t.Cleanup(cancel)
+	run, done := runPanickingAfterWithError(t, time.Millisecond)
+	cbErrs := []error{}
+	cb := func(err error) {
+		cbErrs = append(cbErrs, err)
+	}
+	a := NewNonBlockingStartStopAdapter(newTestConsumer(t, run), cb)
+
+	if err := a.Start(ctx); err != nil {
+		t.Errorf("expected nil error, got %s", err)
+	}
+	<-done
+	// It can take a little while for the panic to propagate even after done is closed.
+	startedWaiting := time.Now()
+	for len(cbErrs) == 0 && time.Since(startedWaiting) < time.Second {
+		time.Sleep(time.Microsecond)
+	}
+	if len(cbErrs) < 1 {
+		t.Errorf("expected the callback to be called, but it wasn't")
+		err := cbErrs[0]
+		if !strings.Contains(err.Error(), "dignified panic") {
+			t.Errorf("expected callback error to contain \"dignified panic\", got: %s", err)
+		}
+	}
+}
+
+func TestNonBlockingStartStopAdapter_DoesntRecoversPanicsWithoutCallback(t *testing.T) {
+	// This can't really be tested. Why? Because the panic occurs in a separate goroutine,
+	// and there's no way for the test to recover that panic. It will just bubble up until
+	// it crashes the entire test.
+}
+
+type testConsumer struct {
+	run func(context.Context) error
+	t   testing.TB
+}
+
+func newTestConsumer(t testing.TB, run func(context.Context) error) *testConsumer {
+	if run == nil {
+		run = runReturningImmediately
+	}
+	return &testConsumer{
+		run: run,
+		t:   t,
+	}
+}
+
+func (c *testConsumer) Run(ctx context.Context) error {
+	c.t.Helper()
+	if c.run != nil {
+		return c.run(ctx)
+	}
+	return nil
+}
+
+func runUntilCanceled(t testing.TB) (func(ctx context.Context) error, <-chan struct{}) {
+	t.Helper()
+	started := make(chan struct{})
+	return func(ctx context.Context) error {
+		t.Helper()
+		close(started)
+		<-ctx.Done()
+		if err := ctx.Err(); !errors.Is(err, context.Canceled) {
+			return err
+		}
+		return nil
+	}, started
+}
+
+func runReturningImmediately(ctx context.Context) error {
+	return nil
+}
+
+func runReturningErrorAfter(t testing.TB, d time.Duration) (func(ctx context.Context) error, <-chan struct{}) {
+	t.Helper()
+	started := make(chan struct{})
+	return func(ctx context.Context) error {
+		t.Helper()
+		defer close(started)
+		select {
+		case <-ctx.Done():
+			if err := ctx.Err(); !errors.Is(err, context.Canceled) {
+				return err
+			}
+		case <-time.After(d):
+			return fmt.Errorf("blowing up")
+		}
+		return nil
+	}, started
+}
+
+func runPanickingAfter(t testing.TB, d time.Duration) (func(ctx context.Context) error, <-chan struct{}) {
+	t.Helper()
+	started := make(chan struct{})
+	return func(ctx context.Context) error {
+		t.Helper()
+		defer close(started)
+		select {
+		case <-ctx.Done():
+			if err := ctx.Err(); !errors.Is(err, context.Canceled) {
+				return err
+			}
+		case <-time.After(d):
+			panic("panic in the disco!")
+		}
+		return nil
+	}, started
+}
+
+func runPanickingAfterWithError(t testing.TB, d time.Duration) (func(ctx context.Context) error, <-chan struct{}) {
+	t.Helper()
+	started := make(chan struct{})
+	return func(ctx context.Context) error {
+		t.Helper()
+		defer close(started)
+		select {
+		case <-ctx.Done():
+			if err := ctx.Err(); !errors.Is(err, context.Canceled) {
+				return err
+			}
+		case <-time.After(d):
+			panic(fmt.Errorf("a dignified panic"))
+		}
+		return nil
+	}, started
+}


### PR DESCRIPTION
While Todd did the Lion's share of the work, some of what was imported was specific to platform and won't generalize well for other projects.

In addition, now that I can see what other uses of the cascading retry consumer might look like, I've re-worked some of the adapters to better be able to service platform, clinic-worker, or other possible services in the future.

Of particular note:

- remove SaramaRunner from go-common, it is platform specific
- add BlockingStartStopAdapter
- add NonBlockingStartStopAdapter
- go over all the names again and work on their consistency