### PR TITLE
Accept 200 as a valid response code for restricted token deletion

### DIFF
--- a/clients/auth.go
+++ b/clients/auth.go
@@ -235,7 +235,7 @@ func (client *AuthClient) DeleteRestrictedToken(tokenID string, token string) er
 	defer res.Body.Close()
 
 	switch res.StatusCode {
-	case http.StatusNoContent:
+	case http.StatusOK:
 		return nil
 	default:
 		return &status.StatusError{


### PR DESCRIPTION
The auth service returns 200 response code if the token is delete or is not found https://github.com/tidepool-org/platform/blob/master/auth/service/api/v1/restricted_token.go#L145-L176